### PR TITLE
Add support for base32 crockford

### DIFF
--- a/base32/src/main/java/io/matthewnelson/base32/Base32.kt
+++ b/base32/src/main/java/io/matthewnelson/base32/Base32.kt
@@ -7,6 +7,11 @@ sealed class Base32 {
 
     internal abstract val encodingTable: ByteArray
 
+    object Crockford: Base32() {
+        override val encodingTable: ByteArray
+            get() = "0123456789ABCDEFGHJKMNPQRSTVWXYZ".encodeUtf8().toByteArray()
+    }
+
     object Default: Base32() {
         override val encodingTable: ByteArray
             get() = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567".encodeUtf8().toByteArray()


### PR DESCRIPTION
This PR adds support for encoding/decoding using <a href="https://www.crockford.com/base32.html">Crockford Base32</a>